### PR TITLE
Auto freeze only configured tags?

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
@@ -76,14 +76,18 @@ object HailData {
     val skipForegroundApp get() = sp.getBoolean(SKIP_FOREGROUND_APP, false)
     val skipNotifyingApp get() = sp.getBoolean(SKIP_NOTIFYING_APP, false)
     val autoFreezeDelay get() = sp.getInt(AUTO_FREEZE_DELAY, 0).toLong()
-    val autoFreezeTags: Set<String> get() {
-        val potentiallyInvalidTags = sp.getStringSet(AUTO_FREEZE_TAGS, setOf("0"))
+    var autoFreezeTags: Set<String> get() {
+        /*val potentiallyInvalidTags = sp.getStringSet(AUTO_FREEZE_TAGS, setOf("0"))
         // This makes sure it is not a tag that doesn't exist anymore (renamed or deleted) by looking at the actual tagId's
         // Unfortunately, this approach loses tags that were renamed...
         // TODO would it be easy to track tag name changes? A rename shouldn't mean a tag can't be auto-frozen...
         val validTags = potentiallyInvalidTags!!.filter { tags.any { tag -> tag.second.toString() == it } }.toSet()
         sp.edit().putStringSet(AUTO_FREEZE_TAGS, validTags).apply()
-        return validTags
+        return validTags */
+        return sp.getStringSet(AUTO_FREEZE_TAGS, setOf("0"))!!.toMutableSet()
+    }
+    set(value) {
+        sp.edit().putStringSet(AUTO_FREEZE_TAGS, value).apply()
     }
 
     val isDeviceAid: Boolean get() = sp.getString(KEY_AID, null) == androidId

--- a/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
@@ -57,6 +57,7 @@ object HailData {
     const val SKIP_FOREGROUND_APP = "skip_foreground_app"
     const val SKIP_NOTIFYING_APP = "skip_notifying_app"
     private const val AUTO_FREEZE_DELAY = "auto_freeze_delay"
+    const val AUTO_FREEZE_TAGS = "auto_freeze_tags"
 
     private val sp = PreferenceManager.getDefaultSharedPreferences(HailApp.app)
     val workingMode get() = sp.getString(WORKING_MODE, MODE_DEFAULT)
@@ -75,6 +76,7 @@ object HailData {
     val skipForegroundApp get() = sp.getBoolean(SKIP_FOREGROUND_APP, false)
     val skipNotifyingApp get() = sp.getBoolean(SKIP_NOTIFYING_APP, false)
     val autoFreezeDelay get() = sp.getInt(AUTO_FREEZE_DELAY, 0).toLong()
+    val autoFreezeTags get() = sp.getStringSet(AUTO_FREEZE_TAGS, setOf("0"))
 
     val isDeviceAid: Boolean get() = sp.getString(KEY_AID, null) == androidId
 

--- a/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
@@ -76,7 +76,15 @@ object HailData {
     val skipForegroundApp get() = sp.getBoolean(SKIP_FOREGROUND_APP, false)
     val skipNotifyingApp get() = sp.getBoolean(SKIP_NOTIFYING_APP, false)
     val autoFreezeDelay get() = sp.getInt(AUTO_FREEZE_DELAY, 0).toLong()
-    val autoFreezeTags get() = sp.getStringSet(AUTO_FREEZE_TAGS, setOf("0"))
+    val autoFreezeTags: Set<String> get() {
+        val potentiallyInvalidTags = sp.getStringSet(AUTO_FREEZE_TAGS, setOf("0"))
+        // This makes sure it is not a tag that doesn't exist anymore (renamed or deleted) by looking at the actual tagId's
+        // Unfortunately, this approach loses tags that were renamed...
+        // TODO would it be easy to track tag name changes? A rename shouldn't mean a tag can't be auto-frozen...
+        val validTags = potentiallyInvalidTags!!.filter { tags.any { tag -> tag.second.toString() == it } }.toSet()
+        sp.edit().putStringSet(AUTO_FREEZE_TAGS, validTags).apply()
+        return validTags
+    }
 
     val isDeviceAid: Boolean get() = sp.getString(KEY_AID, null) == androidId
 

--- a/app/src/main/kotlin/com/aistra/hail/ui/HailActivity.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/HailActivity.kt
@@ -13,7 +13,7 @@ open class HailActivity : AppCompatActivity() {
         val start = hasUnfrozen
             ?: HailData.checkedList.any {
                 !AppManager.isAppFrozen(it.packageName) &&
-                        HailData.autoFreezeTags!!.contains(it.tagId.toString())
+                        HailData.autoFreezeTags.contains(it.tagId.toString())
             }
         applicationContext.let {
             val intent = Intent(it, AutoFreezeService::class.java)

--- a/app/src/main/kotlin/com/aistra/hail/ui/HailActivity.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/HailActivity.kt
@@ -11,7 +11,10 @@ open class HailActivity : AppCompatActivity() {
     fun setAutoFreezeService(hasUnfrozen: Boolean? = null) {
         if (HailData.autoFreezeAfterLock.not()) return
         val start = hasUnfrozen
-            ?: HailData.checkedList.any { !AppManager.isAppFrozen(it.packageName) }
+            ?: HailData.checkedList.any {
+                !AppManager.isAppFrozen(it.packageName) &&
+                        HailData.autoFreezeTags!!.contains(it.tagId.toString())
+            }
         applicationContext.let {
             val intent = Intent(it, AutoFreezeService::class.java)
             when {

--- a/app/src/main/kotlin/com/aistra/hail/ui/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/home/HomeFragment.kt
@@ -348,6 +348,7 @@ class HomeFragment : MainFragment(),
         val input = DialogInputBinding.inflate(layoutInflater, FrameLayout(activity), true)
         input.inputLayout.setHint(if (list != null) R.string.action_tag_add else R.string.action_tag_set)
         list ?: input.editText.setText(HailData.tags[binding.tabs.selectedTabPosition].first)
+        val selectedTabId = HailData.tags[binding.tabs.selectedTabPosition].second
         MaterialAlertDialogBuilder(activity)
             .setView(input.root.parent as View)
             .setPositiveButton(android.R.string.ok) { _, _ ->
@@ -370,7 +371,15 @@ class HomeFragment : MainFragment(),
                         if (!defaultTab) HomeAdapter.currentList.forEach { it.tagId = tagId }
                         getTabAt(selectedTabPosition)!!.text = tagName
                     }
+
+                    HailData.autoFreezeTags = HailData.autoFreezeTags.toMutableSet().apply {
+                        if (list == null && selectedTabId != 0) { // A non-default tag was renamed
+                            remove(selectedTabId.toString())
+                            add(tagId.toString()) // This also adds new tags per default to autoFreezeTags. // TODO is this okay?
+                        }
+                    }
                 }
+
                 HailData.saveApps()
                 HailData.saveTags()
             }
@@ -383,6 +392,11 @@ class HomeFragment : MainFragment(),
                         removeTabAt(selectedTabPosition)
                         if (tabCount == 1) visibility = View.GONE
                     }
+
+                    HailData.autoFreezeTags = HailData.autoFreezeTags.toMutableSet().apply {
+                        remove(selectedTabId.toString())
+                    }
+
                     HailData.saveApps()
                     HailData.saveTags()
                 }

--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -62,6 +62,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
             }
             entries = tagFirsts.toTypedArray()
             entryValues = tagSeconds.toTypedArray()
+            values = HailData.autoFreezeTags // This sets the "checked" boxes and is actually only necessary the first time it runs. If not, the "default" tag wouldn't be selected. I can't think of a nice way of just running this the first time.
         }
     }
 

--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -12,6 +12,7 @@ import androidx.core.content.getSystemService
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
+import androidx.preference.MultiSelectListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.aistra.hail.R
@@ -51,6 +52,16 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
                 startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
                 false
             } else true
+        }
+        findPreference<MultiSelectListPreference>(HailData.AUTO_FREEZE_TAGS)?.apply {
+            val tagFirsts = mutableListOf<CharSequence>()
+            val tagSeconds = mutableListOf<CharSequence>()
+            HailData.tags.forEach { tag ->
+                tagFirsts.add(tag.first)
+                tagSeconds.add(tag.second.toString())
+            }
+            entries = tagFirsts.toTypedArray()
+            entryValues = tagSeconds.toTypedArray()
         }
     }
 

--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -63,7 +63,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
             entries = tagFirsts.toTypedArray()
             entryValues = tagSeconds.toTypedArray()
             values = HailData.autoFreezeTags // This sets the "checked" boxes and is actually only necessary the first time it runs. If not, the "default" tag wouldn't be selected. I can't think of a nice way of just running this the first time.
-            setSummaryFromValues(HailData.autoFreezeTags!!)
+            setSummaryFromValues(HailData.autoFreezeTags)
             setOnPreferenceChangeListener { _, value ->
                 setSummaryFromValues(value as Set<String>)
                 true

--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -63,7 +63,16 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
             entries = tagFirsts.toTypedArray()
             entryValues = tagSeconds.toTypedArray()
             values = HailData.autoFreezeTags // This sets the "checked" boxes and is actually only necessary the first time it runs. If not, the "default" tag wouldn't be selected. I can't think of a nice way of just running this the first time.
+            setSummaryFromValues(HailData.autoFreezeTags!!)
+            setOnPreferenceChangeListener { _, value ->
+                setSummaryFromValues(value as Set<String>)
+                true
+            }
         }
+    }
+
+    private fun MultiSelectListPreference.setSummaryFromValues(values: Set<String>) {
+        summary = values.joinToString(", ") { entries[findIndexOfValue(it)] }
     }
 
     override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {

--- a/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
+++ b/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
@@ -39,5 +39,5 @@ class AutoFreezeWorker(context: Context, params: WorkerParameters) : Worker(cont
         ))
                 || (HailData.skipNotifyingApp && appInfo.packageName in AutoFreezeService.instance.activeNotifications.map { it.packageName })
                 || appInfo.whitelisted
-                || !HailData.autoFreezeTags!!.contains(appInfo.tagId.toString())
+                || !HailData.autoFreezeTags.contains(appInfo.tagId.toString())
 }

--- a/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
+++ b/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
@@ -39,4 +39,5 @@ class AutoFreezeWorker(context: Context, params: WorkerParameters) : Worker(cont
         ))
                 || (HailData.skipNotifyingApp && appInfo.packageName in AutoFreezeService.instance.activeNotifications.map { it.packageName })
                 || appInfo.whitelisted
+                || !HailData.autoFreezeTags!!.contains(appInfo.tagId.toString())
 }

--- a/app/src/main/res/drawable/ic_outline_local_offer.xml
+++ b/app/src/main/res/drawable/ic_outline_local_offer.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21.41,11.58l-9,-9C12.05,2.22 11.55,2 11,2H4c-1.1,0 -2,0.9 -2,2v7c0,0.55 0.22,1.05 0.59,1.42l9,9c0.36,0.36 0.86,0.58 1.41,0.58s1.05,-0.22 1.41,-0.59l7,-7c0.37,-0.36 0.59,-0.86 0.59,-1.41s-0.23,-1.06 -0.59,-1.42zM13,20.01L4,11V4h7v-0.01l9,9 -7,7.02z"/>
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.5,6.5m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+</vector>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -51,14 +51,6 @@
         <item>shizuku_disable</item>
         <item>shizuku_suspend</item>
     </string-array>
-    <string-array name="auto_freeze_tags_entries">
-        <item>Default</item>
-        <item>A test tag</item>
-    </string-array>
-    <string-array name="auto_freeze_tags_values">
-        <item>default</item>
-        <item>a_test_tag</item>
-    </string-array>
     <string-array name="empty_array"/>
     <string-array name="donate_payment_entries">
         <item>@string/donate_alipay</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -51,6 +51,15 @@
         <item>shizuku_disable</item>
         <item>shizuku_suspend</item>
     </string-array>
+    <string-array name="auto_freeze_tags_entries">
+        <item>Default</item>
+        <item>A test tag</item>
+    </string-array>
+    <string-array name="auto_freeze_tags_values">
+        <item>default</item>
+        <item>a_test_tag</item>
+    </string-array>
+    <string-array name="empty_array"/>
     <string-array name="donate_payment_entries">
         <item>@string/donate_alipay</item>
         <item>@string/donate_wechat</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="auto_freeze">Auto freeze</string>
     <string name="auto_freeze_notification_title">Auto freeze service is running</string>
     <string name="auto_freeze_after_lock">After screen locked</string>
+    <string name="auto_freeze_tags">Auto-freeze tags</string>
     <string name="skip_while_charging">Skip while charging</string>
     <string name="skip_foreground_app">Skip foreground app</string>
     <string name="title_customize">Customize</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -81,12 +81,12 @@
             app:singleLineTitle="false"
             app:title="@string/skip_notifying_app" />
         <MultiSelectListPreference
-            app:dialogTitle="Auto freeze tags"
+            app:dialogTitle="@string/auto_freeze_tags"
             app:dependency="auto_freeze_after_lock"
             app:icon="@drawable/ic_outline_local_offer"
             app:key="auto_freeze_tags"
             app:summary=""
-            app:title="Auto freeze tags"
+            app:title="@string/auto_freeze_tags"
             app:entries="@array/empty_array"
             app:entryValues="@array/empty_array"
             app:defaultValue="@array/empty_array" />

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -80,5 +80,15 @@
             app:key="skip_notifying_app"
             app:singleLineTitle="false"
             app:title="@string/skip_notifying_app" />
+        <MultiSelectListPreference
+            app:dialogTitle="Auto freeze tags"
+            app:dependency="auto_freeze_after_lock"
+            app:icon="@drawable/ic_outline_local_offer"
+            app:key="auto_freeze_tags"
+            app:summary=""
+            app:title="Auto freeze tags"
+            app:entries="@array/empty_array"
+            app:entryValues="@array/empty_array"
+            app:defaultValue="@array/empty_array" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Hi @aistra0528,

First of all, thank you very much for this cool app!! :clap::clap::clap: 

Would you be willing to merge an option to only auto-freeze certain tags?
I've already started working on it :smile: This is still very much a **WIP**..

If you're interested, I'll try to finish it and polish it a little. If not, I'll keep a not-so-nice fork for myself :wink:

#### Working for now

- New setting to choose which tags should be frozen.
- Auto freeze ignores the tags which aren't selected.

#### Yet to do

- It would be nice not to start the auto-freeze service at all (so that the notification isn't shown) if the launched apps aren't supposed to be frozen. I still have to dig in a little deeper into the code to see exactly when the service gets started, but I think I should be able to find it.
- Maybe only show the setting if more than one tag exists?
- Clean up root_preferences.xml and use strings from resource and not hard-coded ones.
- I think it would be nice to add a summary to the setting listing the "freezable" tags. What do you think?

I'm open to all kinds of suggestions. I'll try to follow your style but don't hesitate on telling me if there is something you don't like or if there is something that could be solved in a nicer/better way.

Again, thank you very much! :+1: 

Edit (20221003): add todo (root_preferences and strings)
Edit (20221003): add summary to setting