### PR TITLE
Do not start AutoFreezeService because of non-frozen whitelisted apps

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/ui/HailActivity.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/HailActivity.kt
@@ -11,7 +11,7 @@ open class HailActivity : AppCompatActivity() {
     fun setAutoFreezeService(hasUnfrozen: Boolean? = null) {
         if (HailData.autoFreezeAfterLock.not()) return
         val start = hasUnfrozen
-            ?: HailData.checkedList.any { !AppManager.isAppFrozen(it.packageName) }
+            ?: HailData.checkedList.any { !AppManager.isAppFrozen(it.packageName) && !it.whitelisted }
         applicationContext.let {
             val intent = Intent(it, AutoFreezeService::class.java)
             when {


### PR DESCRIPTION
If only whitelisted apps are non-frozen, there is no need to start the auto-freeze service. These won't be auto-frozen anyway.

I think this is the only relevant place, but I'm not completely sure.

Cheers,
Juanito