### PR TITLE
Add 'Freeze non-whitelisted' action to AutoFreezeService Notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
                 <action android:name="${applicationId}.action.FREEZE" />
                 <action android:name="${applicationId}.action.UNFREEZE" />
                 <action android:name="${applicationId}.action.FREEZE_ALL" />
+                <action android:name="${applicationId}.action.FREEZE_NON_WHITELISTED" />
                 <action android:name="${applicationId}.action.UNFREEZE_ALL" />
                 <action android:name="${applicationId}.action.LOCK" />
                 <action android:name="${applicationId}.action.LOCK_FREEZE" />

--- a/app/src/main/kotlin/com/aistra/hail/app/HailApi.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/HailApi.kt
@@ -25,6 +25,8 @@ object HailApi {
     /** @since 0.6.0 */
     const val ACTION_LOCK_FREEZE = "${BuildConfig.APPLICATION_ID}.action.LOCK_FREEZE"
 
+    const val ACTION_FREEZE_NON_WHITELISTED = "${BuildConfig.APPLICATION_ID}.action.FREEZE_NON_WHITELISTED"
+
     fun getIntentForPackage(action: String, packageName: String) =
         Intent(action).putExtra(HailData.KEY_PACKAGE, packageName)
 }

--- a/app/src/main/kotlin/com/aistra/hail/services/AutoFreezeService.kt
+++ b/app/src/main/kotlin/com/aistra/hail/services/AutoFreezeService.kt
@@ -11,7 +11,9 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.getSystemService
 import com.aistra.hail.R
+import com.aistra.hail.app.AppManager
 import com.aistra.hail.app.HailApi
+import com.aistra.hail.app.HailData
 import com.aistra.hail.receiver.ScreenOffReceiver
 
 class AutoFreezeService : NotificationListenerService() {
@@ -26,12 +28,20 @@ class AutoFreezeService : NotificationListenerService() {
             Intent(HailApi.ACTION_FREEZE_ALL),
             PendingIntent.FLAG_IMMUTABLE
         )
+        val freezeNonWhitelisted = PendingIntent.getActivity(
+            applicationContext,
+            0,
+            Intent(HailApi.ACTION_FREEZE_NON_WHITELISTED),
+            PendingIntent.FLAG_IMMUTABLE
+        )
         val notification = NotificationCompat.Builder(this, channelID)
             .setContentTitle(getString(R.string.auto_freeze_notification_title))
             .setSmallIcon(R.drawable.ic_round_frozen)
             .addAction(R.drawable.ic_round_frozen, getString(R.string.action_freeze_all), freezeAll)
-            .build()
-        startForeground(100, notification)
+        if (HailData.checkedList.any { it.whitelisted }) {
+            notification.addAction(R.drawable.ic_round_frozen, getString(R.string.action_freeze_non_whitelisted), freezeNonWhitelisted)
+        }
+        startForeground(100, notification.build())
         return START_STICKY
     }
 

--- a/app/src/main/kotlin/com/aistra/hail/ui/api/ApiActivity.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/api/ApiActivity.kt
@@ -23,6 +23,7 @@ class ApiActivity : HailActivity() {
                 HailApi.ACTION_UNFREEZE -> setAppFrozen(targetPackage, false)
                 HailApi.ACTION_FREEZE_ALL -> setAllFrozen(true)
                 HailApi.ACTION_UNFREEZE_ALL -> setAllFrozen(false)
+                HailApi.ACTION_FREEZE_NON_WHITELISTED -> setNonWhitelistedFrozen(true)
                 HailApi.ACTION_LOCK -> lockScreen(false)
                 HailApi.ACTION_LOCK_FREEZE -> lockScreen(true)
                 else -> throw IllegalArgumentException("unknown action:\n${intent.action}")
@@ -75,6 +76,32 @@ class ApiActivity : HailActivity() {
         HailData.checkedList.forEach {
             when {
                 AppManager.isAppFrozen(it.packageName) == frozen -> return@forEach
+                AppManager.setAppFrozen(it.packageName, frozen) -> {
+                    i++
+                    name = it.name.toString()
+                }
+                it.packageName != packageName && it.applicationInfo != null -> denied = true
+            }
+        }
+        when {
+            denied && i == 0 -> throw IllegalStateException(getString(R.string.permission_denied))
+            i > 0 -> {
+                HUI.showToast(
+                    if (frozen) R.string.msg_freeze else R.string.msg_unfreeze,
+                    if (i > 1) i.toString() else name
+                )
+                setAutoFreezeService(!frozen)
+            }
+        }
+    }
+
+    private fun setNonWhitelistedFrozen(frozen: Boolean) {
+        var i = 0
+        var denied = false
+        var name = String()
+        HailData.checkedList.forEach {
+            when {
+                AppManager.isAppFrozen(it.packageName) == frozen || it.whitelisted -> return@forEach
                 AppManager.setAppFrozen(it.packageName, frozen) -> {
                     i++
                     name = it.name.toString()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="action_unfreeze_all">Unfreeze all</string>
     <string name="action_freeze_current">Freeze current</string>
     <string name="action_unfreeze_current">Unfreeze current</string>
+    <string name="action_freeze_non_whitelisted">Freeze non-whitelisted</string>
     <string name="action_lock">Lock</string>
     <string name="action_lock_freeze">Lock &amp; Freeze</string>
     <string name="action_launch">Launch</string>


### PR DESCRIPTION
This adds an extra button to the notification that allows to only freeze non-whitelisted apps. It only shows if there's at least one whitelisted app.

It adds a new Api action :shrug: Please let me know if you'd want me to remove that. There is a way around that for sure. Right now, it's just as similar as possible to the other freeze-all action.

I'm not sure you'll want to merge this. But if you want to, there you go :blush: 

Cheers,
Juanito