### PR TITLE
Make AutoFreezeService a little more persistent

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
@@ -53,7 +53,7 @@ object HailData {
     private const val COMPACT_ICON = "compact_icon"
     private const val TILE_LOCK = "tile_lock"
     private const val SYNTHESIZE_ADAPTIVE_ICONS = "synthesize_adaptive_icons"
-    private const val AUTO_FREEZE_AFTER_LOCK = "auto_freeze_after_lock"
+    const val AUTO_FREEZE_AFTER_LOCK = "auto_freeze_after_lock"
     private const val SKIP_WHILE_CHARGING = "skip_while_charging"
     const val SKIP_FOREGROUND_APP = "skip_foreground_app"
     const val SKIP_NOTIFYING_APP = "skip_notifying_app"

--- a/app/src/main/kotlin/com/aistra/hail/receiver/ScreenOffReceiver.kt
+++ b/app/src/main/kotlin/com/aistra/hail/receiver/ScreenOffReceiver.kt
@@ -3,15 +3,12 @@ package com.aistra.hail.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.aistra.hail.services.AutoFreezeService
 import com.aistra.hail.work.HWork
 
 class ScreenOffReceiver: BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_SCREEN_OFF) {
             HWork.setAutoFreeze()
-            val serviceIntent = Intent(context, AutoFreezeService::class.java)
-            context.stopService(serviceIntent)
         }
     }
 }

--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -52,6 +52,12 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
                 false
             } else true
         }
+        findPreference<Preference>(HailData.AUTO_FREEZE_AFTER_LOCK)?.setOnPreferenceChangeListener { _, autoFreezeAfterLock ->
+            if ((autoFreezeAfterLock as Boolean).not()) {
+                requireContext().stopService(Intent(requireContext(), AutoFreezeService::class.java))
+            }
+            true
+        }
     }
 
     override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {

--- a/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
+++ b/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
@@ -13,9 +13,8 @@ import com.aistra.hail.utils.HSystem
 
 class AutoFreezeWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
     override fun doWork(): Result {
-        if (!HailData.autoFreezeAfterLock  // some tasks might be scheduled before disabling auto-freeze
-            || HSystem.isInteractive(applicationContext)
-            || isSkipWhileCharging(applicationContext)) return Result.success()
+        if (HSystem.isInteractive(applicationContext)
+            || isSkipWhileCharging(applicationContext)) return Result.success() // Not stopping the AutoFreezeService here. The worker will run at some point. Then we'll stop the Service
         var i = 0
         var denied = false
         HailData.checkedList.forEach {

--- a/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
+++ b/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
@@ -1,6 +1,7 @@
 package com.aistra.hail.work
 
 import android.content.Context
+import android.content.Intent
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.aistra.hail.HailApp
@@ -25,7 +26,12 @@ class AutoFreezeWorker(context: Context, params: WorkerParameters) : Worker(cont
                     denied = true
             }
         }
-        return if (denied && i == 0) Result.failure() else Result.success()
+        return if (denied && i == 0) {
+            Result.failure()
+        } else {
+            applicationContext.stopService(Intent(applicationContext, AutoFreezeService::class.java))
+            Result.success()
+        }
     }
 
     private fun isSkipWhileCharging(context: Context): Boolean =


### PR DESCRIPTION
I think it makes sense to not stop the AutoFreezeService until the apps have actually been frozen (or there's been an attempt to do so) i.e. until the AutoFreezeWorker has run and not immediately returned.

I noticed it because my device sometimes switches the screen on short after it's been switched off and this causes the apps to not get frozen because the screen is on. Which is nice. Unfortunately, it wouldn't try again the next time I switched the screen off (because the service wasn't running anymore). In my opinion, this would've been nice.

This PR (the second commit) also removes the need to check whether the setting is on or off, as the service is switched off immediately if the setting is switched off.