### PR TITLE
fix: Show/hide the terminal menu when changing modes

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.provider.Settings
+import android.util.Log
 import android.view.*
 import android.widget.FrameLayout
 import androidx.appcompat.content.res.AppCompatResources
@@ -193,6 +194,8 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
     }
 
     override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {
+        // Show/hide terminal menu.
+        activity?.invalidateOptionsMenu()
         val mode = newValue as String
         when {
             mode.startsWith(HailData.OWNER) -> if (!HPolicy.isDeviceOwnerActive) {
@@ -274,6 +277,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
                 false
             }
         }
+
         return true
     }
 
@@ -321,6 +325,10 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
 
     override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_settings, menu)
+    }
+
+    override fun onPrepareMenu(menu: Menu) {
+        super.onPrepareMenu(menu)
         if (HailData.workingMode.startsWith(HailData.SU) || HailData.workingMode.startsWith(HailData.SHIZUKU))
             menu.findItem(R.id.action_terminal).isVisible = true
         else if (HPolicy.isDeviceOwnerActive)


### PR DESCRIPTION
Show/hide the terminal menu when changing modes
This pr may not compatible with https://github.com/aistra0528/Hail/pull/131

---
切换模式时显示/隐藏终端菜单

此 pr 可能不兼容 https://github.com/aistra0528/Hail/pull/131