### PR TITLE
fix: crash because fragment tag

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/main/MainActivity.kt
@@ -11,7 +11,7 @@ import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import androidx.navigation.findNavController
+import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
@@ -72,7 +72,10 @@ class MainActivity : AppCompatActivity(), NavController.OnDestinationChangedList
         setSupportActionBar(appBarMain.toolbar)
         fab = appBarMain.fab
         appbar = appBarMain.appBarLayout
-        navController = findNavController(R.id.nav_host_fragment)
+
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        val navController = navHostFragment.navController
         navController.addOnDestinationChangedListener(this@MainActivity)
         appBarConfiguration = AppBarConfiguration.Builder(
             R.id.nav_home, R.id.nav_apps, R.id.nav_settings, R.id.nav_about

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -7,7 +7,7 @@
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:showIn="@layout/app_bar_main">
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -14,6 +14,5 @@
         android:layout_height="match_parent"
         app:defaultNavHost="true"
         app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/mobile_navigation"
-        tools:ignore="FragmentTagUsage" />
+        app:navGraph="@navigation/mobile_navigation" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
这个问题是由于 `fragment` 标签会影响生命周期导致 fragment 在 activity 初始化完前初始化导致的。

解决方法是将 `fragment` 换成 `FragmentContainerView`

详情信息：https://developer.android.google.cn/guide/fragments/lifecycle?hl=zh-cn#states

---

This problem is caused by the fact that the `fragment` tag affects the lifecycle and causes the fragment to be initialized before the activity is initialized.

The solution is to replace `fragment` with `FragmentContainerView`.

For more information: https://developer.android.com/guide/fragments/lifecycle#states