### PR TITLE
Refactor optimize edgetoedge

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/extensions/InsetsExtensions.kt
+++ b/app/src/main/kotlin/com/aistra/hail/extensions/InsetsExtensions.kt
@@ -1,12 +1,12 @@
 package com.aistra.hail.extensions
 
-import android.content.Context
+import android.view.View
 import androidx.core.graphics.Insets
 
-fun Insets.getStart(context: Context): Int {
-    return if (context.isRtl) right else left
+fun Insets.getStart(view: View): Int {
+    return if (view.isRtl) right else left
 }
 
-fun Insets.getEnd(context: Context): Int {
-    return if (context.isRtl) left else right
+fun Insets.getEnd(view: View): Int {
+    return if (view.isRtl) left else right
 }

--- a/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
+++ b/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
@@ -1,6 +1,7 @@
 package com.aistra.hail.extensions
 
 import android.view.View
+import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePaddingRelative
@@ -16,14 +17,15 @@ fun View.applyInsetsPadding(
     top: Boolean = false,
     bottom: Boolean = false
 ) {
+    val origin = Insets.of(paddingLeft, paddingTop, paddingRight, paddingBottom)
     ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
         val insets =
             windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
         v.updatePaddingRelative(
-            start = if (start) insets.getStart(v) else 0,
-            end = if (end) insets.getEnd(v) else 0,
-            bottom = if (bottom) insets.bottom else 0,
-            top = if (top) insets.top else 0,
+            start = origin.getStart(v) + if (start) insets.getStart(v) else 0,
+            end = origin.getEnd(v) + if (end) insets.getEnd(v) else 0,
+            bottom = origin.bottom + if (bottom) insets.bottom else 0,
+            top = origin.top + if (top) insets.top else 0,
         )
         windowInsets
     }

--- a/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
+++ b/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
@@ -1,9 +1,15 @@
 package com.aistra.hail.extensions
 
 import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.marginBottom
+import androidx.core.view.marginLeft
+import androidx.core.view.marginRight
+import androidx.core.view.marginTop
 import androidx.core.view.updatePaddingRelative
 
 val View.isRtl get() = layoutDirection == View.LAYOUT_DIRECTION_RTL
@@ -19,14 +25,36 @@ fun View.applyInsetsPadding(
 ) {
     val origin = Insets.of(paddingLeft, paddingTop, paddingRight, paddingBottom)
     ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
-        val insets =
-            windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+        val insets = windowInsets.getInsets(systemBars() or displayCutout())
         v.updatePaddingRelative(
             start = origin.getStart(v) + if (start) insets.getStart(v) else 0,
             end = origin.getEnd(v) + if (end) insets.getEnd(v) else 0,
             bottom = origin.bottom + if (bottom) insets.bottom else 0,
             top = origin.top + if (top) insets.top else 0,
         )
+        windowInsets
+    }
+}
+
+fun View.applyInsetsMargin(
+    start: Boolean = false,
+    end: Boolean = false,
+    top: Boolean = false,
+    bottom: Boolean = false
+) {
+    val origin = Insets.of(marginLeft, marginTop, marginRight, marginBottom)
+    ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
+        val insets = windowInsets.getInsets(systemBars() or displayCutout())
+        (v.layoutParams as MarginLayoutParams).apply {
+            setMargins(
+                0,
+                origin.top + if (top) insets.top else 0,
+                0,
+                origin.bottom + if (bottom) insets.bottom else 0
+            )
+            marginStart = origin.getStart(v) + if (start) insets.getStart(v) else 0
+            marginEnd = origin.getEnd(v) + if (end) insets.getEnd(v) else 0
+        }
         windowInsets
     }
 }

--- a/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
+++ b/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
@@ -46,14 +46,14 @@ fun View.applyInsetsMargin(
     ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
         val insets = windowInsets.getInsets(systemBars() or displayCutout())
         (v.layoutParams as MarginLayoutParams).apply {
+            val marginStart = origin.getStart(v) + if (start) insets.getStart(v) else 0
+            val marginEnd = origin.getEnd(v) + if (end) insets.getEnd(v) else 0
             setMargins(
-                0,
+                if (isRtl) marginEnd else marginStart,
                 origin.top + if (top) insets.top else 0,
-                0,
+                if (isRtl) marginStart else marginEnd,
                 origin.bottom + if (bottom) insets.bottom else 0
             )
-            marginStart = origin.getStart(v) + if (start) insets.getStart(v) else 0
-            marginEnd = origin.getEnd(v) + if (end) insets.getEnd(v) else 0
         }
         windowInsets
     }

--- a/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
+++ b/app/src/main/kotlin/com/aistra/hail/extensions/ViewExtensions.kt
@@ -20,8 +20,8 @@ fun View.applyInsetsPadding(
         val insets =
             windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
         v.updatePaddingRelative(
-            start = if (start) insets.getStart(context) else 0,
-            end = if (end) insets.getEnd(context) else 0,
+            start = if (start) insets.getStart(v) else 0,
+            end = if (end) insets.getEnd(v) else 0,
             bottom = if (bottom) insets.bottom else 0,
             top = if (top) insets.top else 0,
         )

--- a/app/src/main/kotlin/com/aistra/hail/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/main/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.navigation.ui.setupWithNavController
 import com.aistra.hail.R
 import com.aistra.hail.app.HailData
 import com.aistra.hail.databinding.ActivityMainBinding
+import com.aistra.hail.extensions.applyInsetsMargin
 import com.aistra.hail.extensions.applyInsetsPadding
 import com.aistra.hail.extensions.isLandscape
 import com.aistra.hail.utils.HPolicy
@@ -90,6 +91,7 @@ class MainActivity : AppCompatActivity(), NavController.OnDestinationChangedList
             end = true,
             bottom = true
         )
+        fab.applyInsetsMargin(end = true, bottom = isLandscape)
     }
 
     private fun showGuide() {

--- a/app/src/main/res/layout-land/app_bar_main.xml
+++ b/app/src/main/res/layout-land/app_bar_main.xml
@@ -30,8 +30,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginEnd="@dimen/fab_margin"
-        android:layout_marginBottom="16dp"
+        android:layout_margin="@dimen/fab_margin"
         android:text="@string/action_freeze_current"
         app:icon="@drawable/ic_round_frozen" />
 

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -30,8 +30,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginEnd="@dimen/fab_margin"
-        android:layout_marginBottom="16dp"
+        android:layout_margin="@dimen/fab_margin"
         app:icon="@drawable/ic_round_frozen" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-    <dimen name="fab_margin">48dp</dimen>
-</resources>


### PR DESCRIPTION
1. Adding insets to the fab may otherwise cause some problems
2. `applyInsetsPadding` now can save origin paddings
3. Possible fix for some layout margins that don't require rtl. (This type of layouts is probably not used within the software I guess)