### PR TITLE
fix: target api lints

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/ui/apps/AppsViewModel.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/apps/AppsViewModel.kt
@@ -38,7 +38,7 @@ class AppsViewModel(application: Application) : AndroidViewModel(application) {
             if (refreshStateJob == null || refreshStateJob!!.isCompleted)
                 refreshStateJob = viewModelScope.launch {
                     delay(delayTime)
-                    isRefreshing.postValue(state)
+                    isRefreshing.postValue(true)
                 }
         }
     }

--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -104,7 +104,6 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
         }
     }
 
-    @Suppress("DEPRECATION")
     private fun iconPackDialog() {
         val list = Intent(Intent.ACTION_MAIN).addCategory("com.anddoes.launcher.THEME").let {
             if (HTarget.T) app.packageManager.queryIntentActivities(

--- a/app/src/main/kotlin/com/aistra/hail/utils/HIsland.kt
+++ b/app/src/main/kotlin/com/aistra/hail/utils/HIsland.kt
@@ -72,8 +72,8 @@ object HIsland {
 	private fun setAppFrozen(packageName: String, action: String): Boolean {
         val ownerApp = ownerApp
         // TODO: fix target bug.
-        if (ownerApp == null || ownerApp.isEmpty) {
-            return false
+		if (ownerApp == null || ownerApp.isEmpty) {
+			return false
 		}
 		val intent = Intent(action).apply {
 			data = Uri.fromParts("package", packageName, null)

--- a/app/src/main/kotlin/com/aistra/hail/utils/HPackages.kt
+++ b/app/src/main/kotlin/com/aistra/hail/utils/HPackages.kt
@@ -1,5 +1,6 @@
 package com.aistra.hail.utils
 
+import android.annotation.SuppressLint
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import com.aistra.hail.HailApp.Companion.app
@@ -9,14 +10,14 @@ object HPackages {
 
     fun packageUri(packageName: String) = "package:$packageName"
 
-    @Suppress("DEPRECATION")
+    @SuppressLint("InlinedApi")
     fun getInstalledApplications(flags: Int = PackageManager.MATCH_UNINSTALLED_PACKAGES): List<ApplicationInfo> =
         if (HTarget.T) app.packageManager.getInstalledApplications(
             PackageManager.ApplicationInfoFlags.of(flags.toLong())
         )
         else app.packageManager.getInstalledApplications(flags)
 
-    @Suppress("DEPRECATION")
+    @SuppressLint("InlinedApi")
     fun getUnhiddenPackageInfoOrNull(
         packageName: String, flags: Int = PackageManager.MATCH_UNINSTALLED_PACKAGES
     ) = runCatching {
@@ -26,6 +27,7 @@ object HPackages {
         else app.packageManager.getPackageInfo(packageName, flags)
     }.getOrNull()
 
+    @SuppressLint("InlinedApi")
     fun getApplicationInfoOrNull(
         packageName: String, flags: Int = PackageManager.MATCH_UNINSTALLED_PACKAGES
     ) = runCatching {

--- a/app/src/main/kotlin/com/aistra/hail/utils/HTarget.kt
+++ b/app/src/main/kotlin/com/aistra/hail/utils/HTarget.kt
@@ -1,13 +1,21 @@
 package com.aistra.hail.utils
 
 import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
 
 object HTarget {
-    private fun target(api: Int): Boolean = Build.VERSION.SDK_INT >= api
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.N)
+    val N get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
 
-    val N = target(Build.VERSION_CODES.N)
-    val O = target(Build.VERSION_CODES.O)
-    val P = target(Build.VERSION_CODES.P)
-    val Q = target(Build.VERSION_CODES.Q)
-    val T = target(Build.VERSION_CODES.TIRAMISU)
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
+    val O get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.P)
+    val P get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
+    val Q get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
+    val T get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 }

--- a/app/src/main/kotlin/com/aistra/hail/utils/HTarget.kt
+++ b/app/src/main/kotlin/com/aistra/hail/utils/HTarget.kt
@@ -5,17 +5,17 @@ import androidx.annotation.ChecksSdkIntAtLeast
 
 object HTarget {
     @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.N)
-    val N get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+    val N = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
 
     @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
-    val O get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+    val O = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
 
     @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.P)
-    val P get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+    val P = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
 
     @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
-    val Q get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+    val Q = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
 
     @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
-    val T get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    val T = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 }


### PR DESCRIPTION
错误的检查会导致很多隐藏bug在编译前被忽略，因此需要纠正这些错误，特别是与兼容性有关的检查。
在修复完兼容性检查bug后，我发现了很多与兼容性相关的问题。特别是HIsland中，一些API要求API30，但判断时只做了API24

> 参考自 https://github.com/RikkaApps/RikkaX/tree/master/buildcompat