### PR TITLE
feature: add options of home icon text-size and single-line-display

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
@@ -48,6 +48,8 @@ object HailData {
     const val MODE_ISLAND_HIDE = ISLAND + HIDE
     const val MODE_ISLAND_SUSPEND = ISLAND + SUSPEND
     private const val TILE_ACTION = "tile_action"
+    private const val ICON_TEXT_SIZE = "icon_text_size"
+    private const val ICON_TEXT_SINGLELINE = "icon_text_singleline"
     const val DYNAMIC_SHORTCUT_ACTION = "dynamic_shortcut_action"
     const val ACTION_NONE = "none"
     const val ACTION_FREEZE_ALL = "freeze_all"
@@ -88,6 +90,8 @@ object HailData {
     val grayscaleIcon get() = sp.getBoolean(GRAYSCALE_ICON, true)
     val compactIcon get() = sp.getBoolean(COMPACT_ICON, false)
     val tileAction get() = sp.getString(TILE_ACTION, ACTION_FREEZE_ALL)
+    val iconTextSize get() = sp.getString(ICON_TEXT_SIZE, "")
+    val iconTextSingleline get() = sp.getBoolean(ICON_TEXT_SINGLELINE, false)
     val dynamicShortcutAction get() = sp.getString(DYNAMIC_SHORTCUT_ACTION, ACTION_NONE)!!
     val synthesizeAdaptiveIcons get() = sp.getBoolean(SYNTHESIZE_ADAPTIVE_ICONS, false)
     val autoFreezeAfterLock get() = sp.getBoolean(AUTO_FREEZE_AFTER_LOCK, false)

--- a/app/src/main/kotlin/com/aistra/hail/ui/home/PagerAdapter.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/home/PagerAdapter.kt
@@ -1,5 +1,6 @@
 package com.aistra.hail.ui.home
 
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -62,6 +63,10 @@ class PagerAdapter(private val selectedList: List<AppInfo>) :
                     info.state == AppInfo.STATE_UNKNOWN -> setTextColor(context.getColorStateList(R.color.color_warn))
                     else -> setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodyMedium)
                 }
+                HailData.iconTextSize?.toFloatOrNull()?.let { size->
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, size)
+                }
+                maxLines = if (HailData.iconTextSingleline) 1 else 2
             }
         }
     }

--- a/app/src/main/res/drawable/baseline_text_fields_24.xml
+++ b/app/src/main/res/drawable/baseline_text_fields_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M2.5,4v3h5v12h3V7h5V4H2.5zM21.5,9h-9v3h3v7h3v-7h3V9z" />
+</vector>

--- a/app/src/main/res/drawable/format_line_height.xml
+++ b/app/src/main/res/drawable/format_line_height.xml
@@ -1,0 +1,11 @@
+<!-- drawable/format_line_height.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M21 22H3V20H21V22M21 4H3V2H21V4M10 13.7H14L12 8.3L10 13.7M11.2 6H12.9L17.6 18H15.6L14.7 15.4H9.4L8.5 18H6.5L11.2 6Z" />
+</vector>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -137,4 +137,6 @@
     <string name="mode_su_hide">超级用户 - 隐藏</string>
     <string name="action_fdroid">F-Droid</string>
     <string name="action_skip">跳过</string>
+    <string name="icon_text_size">图标文字大小</string>
+    <string name="icon_text_singleline">图标文字单行</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -82,6 +82,21 @@
         <item>@string/action_lock</item>
         <item>@string/action_lock_freeze</item>
     </string-array>
+    <string-array name="icon_text_size_values">
+        <item>10</item>
+        <item>10.5</item>
+        <item>11</item>
+        <item>11.5</item>
+        <item>12</item>
+        <item>12.5</item>
+        <item>13</item>
+        <item>13.5</item>
+        <item>14</item>
+        <item>14.5</item>
+        <item>15</item>
+        <item>15.5</item>
+        <item>16</item>
+    </string-array>
     <string-array name="tile_action_values">
         <item>freeze_all</item>
         <item>unfreeze_all</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,4 +136,6 @@
     <string name="action_skip">Skip</string>
     <string name="mode_island_hide">Island/Insular - Hide</string>
     <string name="mode_island_suspend">Island/Insular - Suspend</string>
+    <string name="icon_text_size">Icon text size</string>
+    <string name="icon_text_singleline">Icon text singleline</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -35,6 +35,19 @@
                 app:icon="@drawable/ic_outline_layers"
                 app:key="synthesize_adaptive_icons"
                 app:title="@string/synthesize_adaptive_icons"/>
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:icon="@drawable/format_line_height"
+            app:key="icon_text_singleline"
+            app:title="@string/icon_text_singleline"/>
+        <rikka.preference.SimpleMenuPreference
+            app:defaultValue="icon_text_size"
+            app:entries="@array/icon_text_size_values"
+            app:entryValues="@array/icon_text_size_values"
+            app:icon="@drawable/baseline_text_fields_24"
+            app:key="icon_text_size"
+            app:title="@string/icon_text_size"
+            app:useSimpleSummaryProvider="true"/>
         <rikka.preference.SimpleMenuPreference
                 app:defaultValue="freeze_all"
                 app:entries="@array/tile_action_entries"


### PR DESCRIPTION
## feature: add options of home icon text-size and single-line-display in settings


![image](https://github.com/aistra0528/Hail/assets/6268322/ea97b820-d059-4f27-b298-4914cbbb978a)


![image](https://github.com/aistra0528/Hail/assets/6268322/744e0c1c-ea9b-4c70-a84e-bee02f55617f)
