### PR TITLE
fix: get permission denied when setting app suspended in Android Q Shizuku mode

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/utils/HShizuku.kt
+++ b/app/src/main/kotlin/com/aistra/hail/utils/HShizuku.kt
@@ -118,7 +118,7 @@ object HShizuku {
                     suspended,
                     null,
                     null,
-                    if (suspended) suspendDialogInfo else null,
+                    null,
                     callerPackage,
                     userId
                 )


### PR DESCRIPTION
This may fix <https://github.com/aistra0528/Hail/issues/156>