### PR TITLE
改善 AutoFreezeService 启/停时机

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/HailApp.kt
+++ b/app/src/main/kotlin/com/aistra/hail/HailApp.kt
@@ -19,9 +19,8 @@ class HailApp : Application() {
         if (HailData.workingMode.startsWith(HailData.DHIZUKU)) HDhizuku.init()
     }
 
-    fun setAutoFreezeService(enabled: Boolean? = null) {
-        if (HailData.autoFreezeAfterLock.not()) return
-        val start = enabled ?: HailData.checkedList.any {
+    fun setAutoFreezeService(autoFreezeAfterLock: Boolean = HailData.autoFreezeAfterLock) {
+        val start = autoFreezeAfterLock && HailData.checkedList.any {
             it.packageName != packageName
                     && it.applicationInfo != null
                     && !AppManager.isAppFrozen(it.packageName)

--- a/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/settings/SettingsFragment.kt
@@ -79,9 +79,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChan
             } else true
         }
         findPreference<Preference>(HailData.AUTO_FREEZE_AFTER_LOCK)?.setOnPreferenceChangeListener { _, autoFreezeAfterLock ->
-            if (autoFreezeAfterLock == false) {
-                app.setAutoFreezeService(false)
-            }
+            app.setAutoFreezeService(autoFreezeAfterLock as Boolean)
             true
         }
         findPreference<Preference>(HailData.ICON_PACK)?.setOnPreferenceClickListener {

--- a/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
+++ b/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
@@ -21,7 +21,7 @@ class AutoFreezeWorker(context: Context, params: WorkerParameters) : Worker(cont
         return if (result == null) {
             Result.failure()
         } else {
-            app.setAutoFreezeService(false)
+            app.setAutoFreezeService()
             Result.success()
         }
     }


### PR DESCRIPTION
SettingsFragment.kt 的修改解决：勾选自动冻结选项后不会立刻启动 service

AutoFreezeWorker.kt 的修改解决：部分情况下仍需要 service 但它提前结束了（例如锁屏时某应用因有通知被跳过，此时 service 被停止，即使后面应用的通知消失 service 也不会自动重新启动）