### PR TITLE
feat: add systemapp_disable mode

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -122,6 +122,52 @@ This mode invoke non-SDK interface:
 
 - `IPackageManager.setPackagesSuspendedAsUser` to suspend apps.
 
+### System APP - Disable
+
+This mode calls the following APIs:
+
+- `PackageManager.setApplicationEnabledSetting` to disable apps.
+- `ActivityManager.forceStopPackage` to kill apps.
+
+The following privapp-permissions is required:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<permissions>
+    <privapp-permissions package="com.aistra.hail">
+        <permission name="android.permission.PACKAGE_USAGE_STATS" />
+        <permission name="android.permission.FORCE_STOP_PACKAGES" />
+        <permission name="android.permission.CHANGE_COMPONENT_ENABLED_STATE" />
+    </privapp-permissions>
+</permissions>
+```
+
+To use this mode, you should install Hail as a priviledged system app.
+
+The recommended approach is to import Hail when building your ROM, here's an example for `Android.bp`:
+
+```bp
+android_app_import {
+    name: "Hail",
+    apk: "Hail.apk",
+    privileged: true,
+
+    dex_preopt: {
+        enabled: false,
+    },
+    presigned: true,
+    preprocessed: true,
+
+    required: ["privapp-permissions_com.aistra.hail.xml"]
+}
+
+prebuilt_etc {
+    name: "privapp-permissions_com.aistra.hail.xml",
+    src: "privapp-permissions.xml",
+    sub_dir: "permissions",
+}
+```
+
 ## Revert
 
 ### By adb

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,11 @@ android {
         versionName = "1.8.1"
     }
 
+    // Do not compress the dex files, so the apk can be imported as a priviledged app
+    androidResources {
+        noCompress += "dex"
+    }
+
     val signing = if (file("../signing.properties").exists()) {
         signingConfigs.create("release") {
             val props = `java.util`.Properties().apply { load(file("../signing.properties").reader()) }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,12 @@
     <uses-permission
             android:name="android.permission.PACKAGE_USAGE_STATS"
             tools:ignore="ProtectedPermissions"/>
+    <uses-permission
+            android:name="android.permission.FORCE_STOP_PACKAGES"
+            tools:ignore="ProtectedPermissions"/>
+    <uses-permission
+            android:name="android.permission.CHANGE_COMPONENT_ENABLED_STATE"
+            tools:ignore="ProtectedPermissions"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="com.oasisfeng.island.permission.FREEZE_PACKAGE"/>
     <uses-permission android:name="com.oasisfeng.island.permission.SUSPEND_PACKAGE"/>

--- a/app/src/main/kotlin/com/aistra/hail/app/AppManager.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/AppManager.kt
@@ -1,5 +1,6 @@
 package com.aistra.hail.app
 
+import android.content.Context
 import android.content.Intent
 import com.aistra.hail.BuildConfig
 import com.aistra.hail.utils.*
@@ -25,7 +26,7 @@ object AppManager {
                 || HPackages.isAppSuspended(packageName)
     }
 
-    fun setListFrozen(frozen: Boolean, vararg appInfo: AppInfo): String? {
+    fun setListFrozen(ctx: Context, frozen: Boolean, vararg appInfo: AppInfo): String? {
         val excludeMe = appInfo.filter { it.packageName != BuildConfig.APPLICATION_ID }
         var i = 0
         var denied = false
@@ -36,7 +37,7 @@ object AppManager {
             else -> {
                 excludeMe.forEach {
                     when {
-                        setAppFrozen(it.packageName, frozen) -> {
+                        setAppFrozen(ctx, it.packageName, frozen) -> {
                             i++
                             name = it.name.toString()
                         }
@@ -49,7 +50,7 @@ object AppManager {
         return if (denied && i == 0) null else if (i == 1) name else i.toString()
     }
 
-    fun setAppFrozen(packageName: String, frozen: Boolean): Boolean =
+    fun setAppFrozen(ctx: Context, packageName: String, frozen: Boolean): Boolean =
         packageName != BuildConfig.APPLICATION_ID && when (HailData.workingMode) {
             HailData.MODE_OWNER_HIDE -> HPolicy.setAppHidden(packageName, frozen)
             HailData.MODE_OWNER_SUSPEND -> HPolicy.setAppSuspended(packageName, frozen)
@@ -63,6 +64,7 @@ object AppManager {
             HailData.MODE_SHIZUKU_SUSPEND -> HShizuku.setAppSuspended(packageName, frozen)
             HailData.MODE_ISLAND_HIDE -> HIsland.setAppHidden(packageName, frozen)
             HailData.MODE_ISLAND_SUSPEND -> HIsland.setAppSuspended(packageName, frozen)
+            HailData.MODE_SYSTEMAPP_DISABLE -> HSystem.setAppDisabled(ctx, packageName, frozen)
             else -> false
         }
 

--- a/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
+++ b/app/src/main/kotlin/com/aistra/hail/app/HailData.kt
@@ -27,14 +27,18 @@ object HailData {
     const val KEY_FROZEN = "frozen"
     const val WORKING_MODE = "working_mode"
     const val MODE_DEFAULT = "default"
+
     const val OWNER = "owner_"
     const val DHIZUKU = "dhizuku_"
     const val SU = "su_"
     const val SHIZUKU = "shizuku_"
     const val ISLAND = "island_"
+    const val SYSTEMAPP = "systemapp_"
+
     const val DISABLE = "disable"
     const val HIDE = "hide"
     const val SUSPEND = "suspend"
+
     const val MODE_OWNER_HIDE = OWNER + HIDE
     const val MODE_OWNER_SUSPEND = OWNER + SUSPEND
     const val MODE_DHIZUKU_HIDE = DHIZUKU + HIDE
@@ -47,6 +51,10 @@ object HailData {
     const val MODE_SHIZUKU_SUSPEND = SHIZUKU + SUSPEND
     const val MODE_ISLAND_HIDE = ISLAND + HIDE
     const val MODE_ISLAND_SUSPEND = ISLAND + SUSPEND
+    const val MODE_SYSTEMAPP_DISABLE = SYSTEMAPP + DISABLE
+    const val MODE_SYSTEMAPP_HIDE = SYSTEMAPP + HIDE
+    const val MODE_SYSTEMAPP_SUSPEND = SYSTEMAPP + SUSPEND
+
     private const val TILE_ACTION = "tile_action"
     private const val HOME_FONT_SIZE = "home_font_size"
     const val DYNAMIC_SHORTCUT_ACTION = "dynamic_shortcut_action"

--- a/app/src/main/kotlin/com/aistra/hail/ui/api/ApiActivity.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/api/ApiActivity.kt
@@ -98,7 +98,7 @@ class ApiActivity : AppCompatActivity() {
     private fun launchApp(pkg: String, tagId: Int? = null) {
         if (tagId != null) setListFrozen(false, HailData.checkedList.filter { it.tagId == tagId })
         if (AppManager.isAppFrozen(pkg)) {
-            if (AppManager.setAppFrozen(pkg, false)) app.setAutoFreezeService()
+            if (AppManager.setAppFrozen(this, pkg, false)) app.setAutoFreezeService()
             else throw IllegalStateException(getString(R.string.permission_denied))
         }
         packageManager.getLaunchIntentForPackage(pkg)?.let {
@@ -110,7 +110,7 @@ class ApiActivity : AppCompatActivity() {
     private fun setAppFrozen(pkg: String, frozen: Boolean) = when {
         frozen && !HailData.isChecked(pkg) -> throw SecurityException("package not checked")
         AppManager.isAppFrozen(pkg) != frozen && !AppManager.setAppFrozen(
-            pkg, frozen
+            this, pkg, frozen
         ) -> throw IllegalStateException(getString(R.string.permission_denied))
 
         else -> {
@@ -129,7 +129,8 @@ class ApiActivity : AppCompatActivity() {
     ) {
         val filtered =
             list.filter { AppManager.isAppFrozen(it.packageName) != frozen && !(skipWhitelisted && it.whitelisted) }
-        when (val result = AppManager.setListFrozen(frozen, *filtered.toTypedArray())) {
+        when (val result =
+            AppManager.setListFrozen(applicationContext, frozen, *filtered.toTypedArray())) {
             null -> throw IllegalStateException(getString(R.string.permission_denied))
             else -> {
                 HUI.showToast(

--- a/app/src/main/kotlin/com/aistra/hail/ui/home/PagerFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/home/PagerFragment.kt
@@ -319,7 +319,7 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
     }
 
     private fun launchApp(packageName: String) {
-        if (AppManager.isAppFrozen(packageName) && AppManager.setAppFrozen(packageName, false)) {
+        if (AppManager.isAppFrozen(packageName) && AppManager.setAppFrozen(requireContext(), packageName, false)) {
             updateCurrentList()
         }
         app.packageManager.getLaunchIntentForPackage(packageName)?.let {
@@ -345,7 +345,7 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
             }
         }
         val filtered = list.filter { AppManager.isAppFrozen(it.packageName) != frozen }
-        when (val result = AppManager.setListFrozen(frozen, *filtered.toTypedArray())) {
+        when (val result = AppManager.setListFrozen(requireContext(), frozen, *filtered.toTypedArray())) {
             null -> HUI.showToast(R.string.permission_denied)
             else -> {
                 if (updateList) updateCurrentList()

--- a/app/src/main/kotlin/com/aistra/hail/utils/HSystem.kt
+++ b/app/src/main/kotlin/com/aistra/hail/utils/HSystem.kt
@@ -1,14 +1,17 @@
 package com.aistra.hail.utils
 
+import android.app.ActivityManager
 import android.app.AppOpsManager
 import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.os.BatteryManager
 import android.os.PowerManager
 import androidx.core.content.getSystemService
 import com.aistra.hail.app.HailData
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 
 object HSystem {
     fun isInteractive(context: Context): Boolean {
@@ -51,5 +54,36 @@ object HSystem {
             it.last()?.packageName
         }
         return foregroundPackageName == packageName
+    }
+
+    private fun forceStopApp(packageName: String, ctx: Context) = runCatching {
+        ctx.getSystemService<ActivityManager>()!!.let {
+            if (HTarget.P) HiddenApiBypass.invoke(
+                it::class.java, it, "forceStopPackage", packageName
+            ) else it::class.java.getMethod(
+                "forceStopPackage", String::class.java
+            ).invoke(
+                it, packageName
+            )
+        }
+        true
+    }.getOrElse {
+        HLog.e(it)
+        false
+    }
+
+    fun setAppDisabled(ctx: Context, packageName: String, disabled: Boolean): Boolean {
+        HPackages.getApplicationInfoOrNull(packageName) ?: return false
+        if (disabled) forceStopApp(packageName, ctx)
+        runCatching {
+            val newState = when {
+                !disabled -> PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                else -> PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            }
+            ctx.packageManager.setApplicationEnabledSetting(packageName, newState, 0)
+        }.onFailure {
+            HLog.e(it)
+        }
+        return HPackages.isAppDisabled(packageName) == disabled
     }
 }

--- a/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
+++ b/app/src/main/kotlin/com/aistra/hail/work/AutoFreezeWorker.kt
@@ -17,7 +17,7 @@ class AutoFreezeWorker(context: Context, params: WorkerParameters) : Worker(cont
             || isSkipWhileCharging(applicationContext)
         ) return Result.success() // Not stopping the AutoFreezeService here. The worker will run at some point. Then we'll stop the Service
         val checkedList = HailData.checkedList.filter { !isSkipApp(applicationContext, it) }
-        val result = AppManager.setListFrozen(true, *checkedList.toTypedArray())
+        val result = AppManager.setListFrozen(applicationContext, true, *checkedList.toTypedArray())
         return if (result == null) {
             Result.failure()
         } else {

--- a/app/src/main/kotlin/com/aistra/hail/work/FrozenWorker.kt
+++ b/app/src/main/kotlin/com/aistra/hail/work/FrozenWorker.kt
@@ -9,7 +9,7 @@ import com.aistra.hail.app.HailData
 class FrozenWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
     override fun doWork(): Result {
         inputData.getString(HailData.KEY_PACKAGE)?.let {
-            AppManager.setAppFrozen(it, inputData.getBoolean(HailData.KEY_FROZEN, true))
+            AppManager.setAppFrozen(applicationContext, it, inputData.getBoolean(HailData.KEY_FROZEN, true))
             return Result.success()
         }
         return Result.failure()

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -43,6 +43,7 @@
         <item>@string/mode_owner_suspend</item>
         <item>@string/mode_island_hide</item>
         <item>@string/mode_island_suspend</item>
+        <item>@string/mode_systemapp_disable</item>
     </string-array>
     <string-array name="working_mode_values">
         <item>default</item>
@@ -58,6 +59,7 @@
         <item>owner_suspend</item>
         <item>island_hide</item>
         <item>island_suspend</item>
+        <item>systemapp_disable</item>
     </string-array>
     <string-array name="donate_payment_entries">
         <item>@string/donate_alipay</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,9 @@
     <string name="mode_shizuku_disable">Shizuku - Disable</string>
     <string name="mode_shizuku_hide">Shizuku - Hide</string>
     <string name="mode_shizuku_suspend">Shizuku - Suspend</string>
+    <string name="mode_systemapp_disable">System APP - Disable</string>
+    <string name="mode_systemapp_hide">System APP - Hide</string>
+    <string name="mode_systemapp_suspend">System APP - Suspend</string>
     <string name="title_set_owner">Set Device Owner</string>
     <string name="msg_set_owner">Issue the command from adb:\n%s</string>
     <string name="title_remove_owner">Remove Device Owner</string>


### PR DESCRIPTION
## Motivation

To create secure ROMs without root / Shizuku while retaining the ability to freeze apps easily.

BTW, this method should be fastest when configured correctly since it calls system API without any intermediate wrapper.

It's theoritically possible to create Magisk modules that inject Hail into priv-app without building AOSP :)

## Implementation

It simply call `PackageManager.setApplicationEnabledSetting` to change the package state.

The API call requires `android.permission.CHANGE_COMPONENT_ENABLED_STATE` permission, therefore it's only possible when Hail itself is installed as a priviledged system app.

A simple how to note is added to README_EN.md for reference.
