### PR TITLE
feat: Create xposed hook to automatically unfreeze `suspended` app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,4 +104,5 @@ dependencies {
     implementation(libs.commons.text)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.hiddenapibypass)
+    compileOnly(libs.xposed)
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep public class com.aistra.hail.xposed.XposedInterface

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,19 @@
             </intent-filter>
         </activity>
 
+        <meta-data
+            android:name="xposedmodule"
+            android:value="true" />
+        <meta-data
+            android:name="xposeddescription"
+            android:value="@string/xposed_description" />
+        <meta-data
+            android:name="xposedminversion"
+            android:value="53" />
+        <meta-data
+            android:name="xposedscope"
+            android:resource="@array/xposed_scope" />
+
         <provider
                 android:name="rikka.shizuku.ShizukuProvider"
                 android:authorities="${applicationId}.shizuku"

--- a/app/src/main/assets/xposed_init
+++ b/app/src/main/assets/xposed_init
@@ -1,0 +1,1 @@
+com.aistra.hail.xposed.XposedInterface

--- a/app/src/main/kotlin/com/aistra/hail/xposed/LaunchAppHook.kt
+++ b/app/src/main/kotlin/com/aistra/hail/xposed/LaunchAppHook.kt
@@ -1,0 +1,101 @@
+package com.aistra.hail.xposed
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.service.quicksettings.TileService
+import com.aistra.hail.app.HailApi.ACTION_UNFREEZE
+import com.aistra.hail.app.HailData
+import com.aistra.hail.ui.api.ApiActivity
+import com.aistra.hail.xposed.XposedInterface.BaseHook
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+import java.lang.reflect.Method
+
+class LaunchAppHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+    override fun startHook() {
+        appFreezeInject(classLoader)
+    }
+
+    private fun appFreezeInject(classLoader: ClassLoader) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val hook = object : XC_MethodHook() {
+                @Throws(Throwable::class)
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    if (param.args.isNotEmpty() && param.args[0] != null) {
+                        val intent = param.args[0] as Intent
+                        var packageName = intent.getPackage()
+                        val component = intent.component
+                        if (packageName == null && component != null) {
+                            packageName = component.packageName
+                        }
+                        val context = param.thisObject as Context
+                        if (packageName != null && packageName != context.packageName) {
+                            unfreezeApp(context, packageName)
+                        }
+                    }
+                }
+            }
+
+            XposedHelpers.findAndHookMethod(
+                Activity::class.java.name,
+                classLoader,
+                "startActivityForResult",
+                Intent::class.java, Int::class.javaPrimitiveType,
+                Bundle::class.java,
+                hook
+            )
+            XposedHelpers.findAndHookMethod(
+                TileService::class.java.name,
+                classLoader,
+                "startActivityAndCollapse",
+                Intent::class.java, hook
+            )
+            val contextClass = XposedHelpers.findClass(
+                ContextWrapper::class.java.name,
+                classLoader
+            )
+            XposedHelpers.findAndHookMethod(
+                contextClass,
+                "startActivity",
+                Intent::class.java,
+                hook
+            )
+            XposedHelpers.findAndHookMethod(
+                contextClass,
+                "startActivity",
+                Intent::class.java, Bundle::class.java,
+                hook
+            )
+        }
+    }
+
+    private fun unfreezeApp(context: Context, packageName: String) {
+        val packageManager = context.applicationContext.packageManager
+        val method: Method = packageManager.javaClass.getMethod(
+            "isPackageSuspended",
+            String::class.java
+        )
+        if (method.invoke(packageManager, packageName) as Boolean) {
+            val intent = Intent(ACTION_UNFREEZE)
+            intent.putExtra(HailData.KEY_PACKAGE, packageName)
+            context.startActivity(intent)
+
+            /**
+             * It took about 500 milliseconds from [Context.startActivity]
+             * to start [ApiActivity] and successfully unfreeze.
+             * We lack communication between applications, we can only wait.
+             */
+            Thread.sleep(300)
+            repeat(6) {
+                if (!(method.invoke(packageManager, packageName) as Boolean)) return@repeat
+                Thread.sleep(75)
+            }
+        }
+    }
+
+}

--- a/app/src/main/kotlin/com/aistra/hail/xposed/XposedInterface.kt
+++ b/app/src/main/kotlin/com/aistra/hail/xposed/XposedInterface.kt
@@ -1,0 +1,37 @@
+package com.aistra.hail.xposed
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.service.quicksettings.TileService
+import com.aistra.hail.BuildConfig
+import com.aistra.hail.app.HailApi.ACTION_UNFREEZE
+import com.aistra.hail.app.HailData
+import com.aistra.hail.ui.api.ApiActivity
+import de.robv.android.xposed.IXposedHookLoadPackage
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+import java.lang.reflect.Method
+
+class XposedInterface : IXposedHookLoadPackage {
+    @Throws(Throwable::class)
+    override fun handleLoadPackage(loadPackageParam: LoadPackageParam) {
+        if (!loadPackageParam.isFirstApplication) {
+            return
+        }
+
+        if (loadPackageParam.packageName == BuildConfig.APPLICATION_ID) {
+            return
+        }
+
+        LaunchAppHook(loadPackageParam.classLoader).startHook()
+    }
+
+    abstract class BaseHook(protected val classLoader: ClassLoader) {
+        abstract fun startHook()
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -137,6 +137,7 @@
     <string name="mode_su_hide">Root - 隐藏</string>
     <string name="action_fdroid">F-Droid</string>
     <string name="action_skip">跳过</string>
+    <string name="xposed_description">当作用域内的应用尝试打开被暂停的应用时自动解冻被暂停的应用</string>
     <string name="shizuku_hide_adb">Shizuku 正以 adb 权限运行。如需隐藏应用，请通过 root 重新启动 Shizuku。</string>
     <string name="freeze_system_app">冻结或卸载系统应用可能导致设备无法启动。请确保您已知晓操作后果，并提前备份数据或使用支持文件管理的恢复模式。</string>
     <string name="action_continue">继续</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -8,6 +8,9 @@
         <item>90</item>
         <item>120</item>
     </integer-array>
+    <string-array name="xposed_scope">
+        <item>com.android.launcher</item>
+    </string-array>
     <string-array name="home_action_entries">
         <item>@string/action_launch</item>
         <item>@string/action_freeze</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="mode_su_hide">Root - Hide</string>
     <string name="action_fdroid">F-Droid</string>
     <string name="action_skip">Skip</string>
+    <string name="xposed_description">Automatically unfreeze when a scoped app attempts to open a suspended app</string>
     <string name="mode_island_hide">Island/Insular - Hide</string>
     <string name="mode_island_suspend">Island/Insular - Suspend</string>
     <string name="shizuku_hide_adb">Shizuku is running as adb. To hide apps, please restart Shizuku with root.</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ preferenceKtx = "1.2.1"
 shizuku = "13.1.5"
 swiperefreshlayout = "1.1.0"
 workRuntimeKtx = "2.9.1"
+xposed = "82"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose" }
@@ -50,6 +51,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 pinyin4j = { module = "com.belerweb:pinyin4j", version.ref = "pinyin4j" }
 shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
 shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
+xposed = { module = "de.robv.android.xposed:api", version.ref = "xposed" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://api.xposed.info/")
     }
 }
 rootProject.name = "Hail"


### PR DESCRIPTION
用Xposed来Hook了启动应用相关的函数，在启动之前先解冻。
这防止了恼人的 `应用无法使用 `的对话框

解决#70 #187 