### PR TITLE
fix: handle nullability for tabs and adapter in PagerFragment

### DIFF
--- a/app/src/main/kotlin/com/aistra/hail/ui/home/PagerFragment.kt
+++ b/app/src/main/kotlin/com/aistra/hail/ui/home/PagerFragment.kt
@@ -64,9 +64,10 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
         }
         get() = (parentFragment as HomeFragment).multiselect
     private val selectedList get() = (parentFragment as HomeFragment).selectedList
-    private val tabs: TabLayout get() = (parentFragment as HomeFragment).binding.tabs
-    private val adapter get() = (parentFragment as HomeFragment).binding.pager.adapter as HomeAdapter
-    private val tag: Pair<String, Int> get() = HailData.tags[tabs.selectedTabPosition]
+    private val tabs: TabLayout? get() = (parentFragment as? HomeFragment)?.binding?.tabs
+    private val adapter: HomeAdapter? get() = (parentFragment as? HomeFragment)?.binding?.pager?.adapter as? HomeAdapter
+    private val tag: Pair<String, Int>? get() = tabs?.let { HailData.tags.getOrNull(it.selectedTabPosition) }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
@@ -89,7 +90,7 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
                     super.onScrollStateChanged(recyclerView, newState)
                     when (newState) {
                         RecyclerView.SCROLL_STATE_IDLE -> activity.fab.run {
-                            postDelayed({ if (tag == true) show() }, 1000)
+                            postDelayed({ if (tag != null) show() }, 1000)
                         }
 
                         RecyclerView.SCROLL_STATE_DRAGGING -> activity.fab.hide()
@@ -115,9 +116,11 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
         updateCurrentList()
         updateBarTitle()
         activity.appbar.setLiftOnScrollTargetView(binding.recyclerView)
-        tabs.getTabAt(tabs.selectedTabPosition)?.view?.setOnLongClickListener {
-            if (isResumed) showTagDialog()
-            true
+        tabs?.let { tabLayout ->
+            tabLayout.getTabAt(tabLayout.selectedTabPosition)?.view?.setOnLongClickListener {
+                if (isResumed) showTagDialog()
+                true
+            }
         }
         activity.fab.setOnClickListener {
             setListFrozen(true, pagerAdapter.currentList.filterNot { it.whitelisted })
@@ -129,7 +132,7 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
     }
 
     private fun updateCurrentList() = HailData.checkedList.filter {
-        if (query.isEmpty()) tag.second in it.tagIdList
+        if (query.isEmpty()) tag?.second?.let { tagId -> tagId in it.tagIdList } ?: false
         else ((HailData.nineKeySearch && NineKeySearch.search(
             query, it.packageName, it.name.toString()
         )) || FuzzySearch.search(it.packageName, query) || FuzzySearch.search(
@@ -220,20 +223,21 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
 
                 5 -> tagDialog(info)
 
-                6 -> if (tabs.tabCount > 1) MaterialAlertDialogBuilder(requireActivity()).setTitle(R.string.action_unfreeze_tag)
-                    .setItems(HailData.tags.map { it.first }.toTypedArray()) { _, index ->
-                        HShortcuts.addPinShortcut(
-                            info,
-                            pkg,
-                            info.name,
-                            HailApi.getIntentForPackage(HailApi.ACTION_LAUNCH, pkg).addTag(HailData.tags[index].first)
-                        )
-                    }.setPositiveButton(R.string.action_skip) { _, _ ->
-                        HShortcuts.addPinShortcut(
-                            info, pkg, info.name, HailApi.getIntentForPackage(HailApi.ACTION_LAUNCH, pkg)
-                        )
-                    }.setNegativeButton(android.R.string.cancel, null).show()
-                else HShortcuts.addPinShortcut(
+                6 -> tabs?.takeIf { it.tabCount > 1 }?.let {
+                    MaterialAlertDialogBuilder(requireActivity()).setTitle(R.string.action_unfreeze_tag)
+                        .setItems(HailData.tags.map { it.first }.toTypedArray()) { _, index ->
+                            HShortcuts.addPinShortcut(
+                                info,
+                                pkg,
+                                info.name,
+                                HailApi.getIntentForPackage(HailApi.ACTION_LAUNCH, pkg).addTag(HailData.tags[index].first)
+                            )
+                        }.setPositiveButton(R.string.action_skip) { _, _ ->
+                            HShortcuts.addPinShortcut(
+                                info, pkg, info.name, HailApi.getIntentForPackage(HailApi.ACTION_LAUNCH, pkg)
+                            )
+                        }.setNegativeButton(android.R.string.cancel, null).show()
+                } ?: HShortcuts.addPinShortcut(
                     info, pkg, info.name, HailApi.getIntentForPackage(HailApi.ACTION_LAUNCH, pkg)
                 )
 
@@ -447,9 +451,12 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
     }
 
     private fun showTagDialog(list: List<AppInfo>? = null) {
+        val tabLayout = tabs ?: return  // The view has been destroyed; return directly.
+        val homeAdapter = adapter ?: return
+
         val binding = DialogInputBinding.inflate(layoutInflater)
         binding.inputLayout.setHint(R.string.tag)
-        list ?: binding.editText.setText(tag.first)
+        list ?: binding.editText.setText(tag?.first ?: "")
         MaterialAlertDialogBuilder(activity).setTitle(if (list != null) R.string.action_tag_add else R.string.action_tag_set)
             .setView(binding.root).setPositiveButton(android.R.string.ok) { _, _ ->
                 val tagName = binding.editText.text.toString()
@@ -457,11 +464,11 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
                 if (HailData.tags.any { it.first == tagName || it.second == tagId }) return@setPositiveButton
                 if (list != null) { // Add tag
                     HailData.tags.add(tagName to tagId)
-                    adapter.notifyItemInserted(adapter.itemCount - 1)
-                    if (query.isEmpty() && tabs.tabCount == 2) tabs.isVisible = true
+                    homeAdapter.notifyItemInserted(homeAdapter.itemCount - 1)
+                    if (query.isEmpty() && tabLayout.tabCount == 2) tabLayout.isVisible = true
                     if (list == selectedList) triStateTagDialog() else tagDialog(list.first())
                 } else { // Rename tag
-                    val position = tabs.selectedTabPosition
+                    val position = tabLayout.selectedTabPosition
                     val defaultTab = position == 0
                     val oldTagId = HailData.tags[position].second
                     HailData.tags[position] = tagName to if (defaultTab) 0 else tagId
@@ -472,11 +479,11 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
                         }
                         HailData.saveApps()
                     }
-                    adapter.notifyItemChanged(position)
+                    homeAdapter.notifyItemChanged(position)
                 }
                 HailData.saveTags()
             }.apply {
-                val position = tabs.selectedTabPosition
+                val position = tabLayout.selectedTabPosition
                 if (list != null || position == 0) return@apply
                 setNeutralButton(R.string.action_tag_remove) { _, _ ->
                     val tagIdToRemove = HailData.tags[position].second
@@ -486,8 +493,8 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
                         }
                     }
                     HailData.tags.removeAt(position)
-                    adapter.notifyItemRemoved(position)
-                    if (tabs.tabCount == 1) tabs.isVisible = false
+                    homeAdapter.notifyItemRemoved(position)
+                    if (tabLayout.tabCount == 1) tabLayout.isVisible = false
                     HailData.saveApps()
                     HailData.saveTags()
                 }
@@ -517,7 +524,7 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
         for (index in 0 until json.length()) {
             val pkg = json.getString(index)
             if (HPackages.getApplicationInfoOrNull(pkg) != null && !HailData.isChecked(pkg)) {
-                HailData.addCheckedApp(pkg, tag.second, false)
+                HailData.addCheckedApp(pkg, tag?.second ?: 0, false)
                 i++
             }
         }
@@ -531,7 +538,7 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
     private suspend fun importFrozenApp() = withContext(Dispatchers.IO) {
         HPackages.getInstalledApplications().map { it.packageName }
             .filter { AppManager.isAppFrozen(it) && !HailData.isChecked(it) }
-            .onEach { HailData.addCheckedApp(it, tag.second, false) }.size
+            .onEach { HailData.addCheckedApp(it, tag?.second ?: 0, false) }.size
     }
 
     private fun removeCheckedApp(packageName: String, saveApps: Boolean = true) {
@@ -592,7 +599,9 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
             override fun onQueryTextChange(newText: String): Boolean {
                 if (inited) {
                     query = newText
-                    tabs.isVisible = query.isEmpty() && tabs.tabCount > 1
+                    tabs?.run {
+                        isVisible = query.isEmpty() && tabCount > 1
+                    }
                     updateCurrentList()
                 } else inited = true
                 return true
@@ -604,6 +613,8 @@ class PagerFragment : MainFragment(), PagerAdapter.OnItemClickListener, PagerAda
     }
 
     override fun onDestroyView() {
+        activity?.fab?.setOnClickListener(null)
+        activity?.fab?.setOnLongClickListener(null)
         pagerAdapter.onDestroy()
         super.onDestroyView()
         _binding = null


### PR DESCRIPTION
- Made `tabs`, `adapter`, and `tag` properties nullable to safely handle cases where the parent `HomeFragment`'s view has been destroyed.
- Replaced all unsafe accesses with null-safe calls (`?.`, `?.let`, `takeIf`, `? ?:`) across the fragment.
- Cleared FAB click and long-click listeners in `onDestroyView()` to prevent callbacks after view destruction.
- Added a return guard in `showTagDialog()` when `tabs` or `adapter` is null.